### PR TITLE
Add a docstring placeholder to make "pytest --fixtures" happy.

### DIFF
--- a/pytest_cafe_config.py
+++ b/pytest_cafe_config.py
@@ -43,4 +43,8 @@ def pytest_configure(config):
 
 @pytest.fixture
 def bar(request):
+    """Docstring for this fixture
+
+    Document this fixture here.
+    """
     return request.config.option.cafe_proj


### PR DESCRIPTION
pytest --fixtures complains about a missing docstring on the bar fixture so lets slap a placeholder docstring in there.